### PR TITLE
not adding undefined to the list of extentions if one is not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ Registry.prototype.extensionsForType = function(type) {
   var registered = this.registeredForType(type);
 
   var extensions =  registered.reduce(function(memo, plugin) {
-    return plugin.ext ? memo.concat(plugin.ext) : memo;
-  }, [type]);
+    return memo.concat(plugin.ext);
+  }, [type]).filter(Boolean);
 
   extensions = require('lodash/uniq')(extensions);
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ Registry.prototype.extensionsForType = function(type) {
   var registered = this.registeredForType(type);
 
   var extensions =  registered.reduce(function(memo, plugin) {
-    return memo.concat(plugin.ext);
+    return plugin.ext ? memo.concat(plugin.ext) : memo;
   }, [type]);
 
   extensions = require('lodash/uniq')(extensions);

--- a/tests/unit/registry-test.js
+++ b/tests/unit/registry-test.js
@@ -117,6 +117,13 @@ describe('Plugin Loader', function() {
 
       expect(extensions).to.deep.equal(['css', 'scss', 'sass', 'foo']);
     });
+
+    it('will removed non defined extensions from list', function() {
+      registry.add('css', 'broccoli-foo');
+      var extensions = registry.extensionsForType('css');
+
+      expect(extensions).to.deep.equal(['css', 'scss', 'sass']);
+    });
   });
 
   describe('adds a plugin directly if it is provided', function() {


### PR DESCRIPTION
this was found in https://github.com/ebryn/ember-component-css/pull/132 and was due to ember-cli-sass not including an extension. PR was made to add extension to that project https://github.com/aexmachina/ember-cli-sass/pull/113 but should be able to add preprocessors without defining extensions.