### PR TITLE
Upgrade to broccoli-clean-css@2 (uses clean-css@4).

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-preprocessor-registry#readme",
   "dependencies": {
-    "broccoli-clean-css": "^1.1.0",
+    "broccoli-clean-css": "^2.0.0",
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "debug": "^2.2.0",

--- a/preprocessors.js
+++ b/preprocessors.js
@@ -108,15 +108,16 @@ module.exports.preprocessMinifyCss = function(tree, options) {
   var plugins = options.registry.load('minify-css');
 
   if (plugins.length === 0) {
-    var compiler = require('broccoli-clean-css');
-    return compiler(tree, options);
+    var CleanCSS = require('broccoli-clean-css');
+    return new CleanCSS(tree, options);
   } else if (plugins.length > 1) {
     throw new Error('You cannot use more than one minify-css plugin at once.');
   }
 
   var plugin = plugins[0];
+  var Preprocessor = relativeRequire(plugin.name);
 
-  return relativeRequire(plugin.name).call(null, tree, options);
+  return new Preprocessor(tree, options);
 };
 
 module.exports.preprocessCss = function(tree, inputPath, outputPath, options) {


### PR DESCRIPTION
Many fixes landed in clean-css@4, this updates our version of broccoli-clean-css to utilize the latest version (updated to class syntax).

Also closes https://github.com/ember-cli/ember-cli-preprocessor-registry/issues/15.