### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-preprocessor-registry#readme",
   "dependencies": {
-    "broccoli-clean-css": "^1.1.0",
-    "broccoli-funnel": "^1.0.0",
-    "broccoli-merge-trees": "^1.0.0",
-    "debug": "^2.2.0",
-    "ember-cli-lodash-subset": "^1.0.7",
+    "broccoli-clean-css": "^2.0.1",
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^3.0.1",
+    "debug": "^3.0.1",
+    "ember-cli-lodash-subset": "^2.0.1",
     "process-relative-require": "^1.0.0",
-    "silent-error": "^1.0.0"
+    "silent-error": "^1.1.0"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
-    "mocha": "^3.0.1"
+    "chai": "^4.1.2",
+    "mocha": "^5.2.0"
   }
 }

--- a/tests/unit/registry-test.js
+++ b/tests/unit/registry-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var assign         = require('ember-cli-lodash-subset').assign;
 var expect         = require('chai').expect;
 var PluginRegistry = require('../../');
 
@@ -20,7 +19,7 @@ describe('Plugin Loader', function() {
     };
 
     app = { name: 'some-application-name' };
-    registry = new PluginRegistry(assign(pkg.devDependencies, pkg.dependencies), app);
+    registry = new PluginRegistry(Object.assign(pkg.devDependencies, pkg.dependencies), app);
     registry.add('css', 'fake-sass-1', ['scss', 'sass']);
     registry.add('css', 'fake-sass-2', ['scss', 'sass']);
   });


### PR DESCRIPTION
Once released will allow `ember-cli` to be installed without warning:

`warning ember-cli > ember-cli-preprocess-registry > broccoli-funnel > exists-sync@0.0.4: Please replace with usage of fs.existsSync`