### PR TITLE
[Chore] Upgrade broccoli-funnel from v1 to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-preprocessor-registry#readme",
   "dependencies": {
-    "broccoli-funnel": "^1.0.0",
+    "broccoli-funnel": "^2.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "debug": "^2.2.0",
     "silent-error": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,15 +94,14 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-broccoli-funnel@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
+broccoli-funnel@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
   dependencies:
     array-equal "^1.0.0"
     blank-object "^1.0.1"
     broccoli-plugin "^1.3.0"
     debug "^2.2.0"
-    exists-sync "0.0.4"
     fast-ordered-set "^1.0.0"
     fs-tree-diff "^0.5.3"
     heimdalljs "^0.2.0"
@@ -423,10 +422,6 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-exists-sync@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
 
 exit-hook@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
This PR aims at removing the implied dependency to exists-sync.

Indeed, the following warning is triggered while adding ember-cli to an existing project:
`warning ember-cli > ember-cli-preprocess-registry > broccoli-funnel > exists-sync@0.0.4: Please replace with usage of fs.existsSync`

The warning is due to exists-sync usage through broccoli-funnel@1.x.