### PR TITLE
package.json: Fix Node.js support declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "ember-cli Contributors",
   "license": "MIT",
   "engines": {
-    "node": "> 4"
+    "node": ">= 4"
   },
   "bugs": {
     "url": "https://github.com/ember-cli/ember-cli-preprocessor-registry/issues"


### PR DESCRIPTION
Since TravisCI is configured to run on Node 4 and 6 I'm assuming this was a typo in the Node.js support declaration